### PR TITLE
Default to running tests in the `test` directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = function mocha ( inputdir, options, cb ) {
 
   var mocha = new Mocha( options );
 
+  options.testDir = options.testDir || 'test';
   mocha.files = sander.readdirSync( inputdir, options.testDir ).filter( n => n.endsWith('.js') ).map(function ( file ) {
     return path.join( inputdir, options.testDir, file );
   });


### PR DESCRIPTION
If we don't specify any testDir the plugin just fails. I tried using just the empty string but it doesn't work properly because it makes mocha trying to run application js files as test files. So I settled to `test` instead.

Tell me what you think !
