### PR TITLE
Properly report failures and add a reportOnly option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,12 @@ module.exports = function mocha ( inputdir, options, cb ) {
       delete require.cache[ file ];
     });
 
-    cb( failures );
+    if (options.reportOnly) {
+      cb();
+    } else if (failures > 0) {
+      cb(new Error('Mocha runner reported some failures.'));
+    } else {
+      cb();
+    }
   });
 };


### PR DESCRIPTION
The callback needs to have a Error object, but `failures` is a number.

Also I think it's useful to have a reportOnly option like the eslint plugin so that we don't fail the build if there is an error (very useful in "serve" mode).
